### PR TITLE
Use `Name` when referring to a property name in Hole semantics

### DIFF
--- a/_includes/home.md
+++ b/_includes/home.md
@@ -110,7 +110,7 @@ Template ::= ( Text | Hole )*
 ![Hole](https://messagetemplates.org/img/railroad/Hole.png)
 
 ```
-Hole ::= '{' ( '@' | '$' )? ( PropertyName | Index ) ( ',' Alignment )? ( ':' Format )? '}'
+Hole ::= '{' ( '@' | '$' )? ( Name | Index ) ( ',' Alignment )? ( ':' Format )? '}'
 ```
 
 ### Name


### PR DESCRIPTION
Just found a small typo in the documentation. The `PropertyName` appears to be an obsolete term and must be replaced with `Name` to conform to grammar rules. Thank you for your efforts in maintaining the specification!